### PR TITLE
Allow granular resource definitions per service

### DIFF
--- a/templates/alertmanager-deployment.yaml
+++ b/templates/alertmanager-deployment.yaml
@@ -47,7 +47,7 @@ spec:
           #     path: /
           #     port: http
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.resources.alertmanager | nindent 12 }}
           envFrom:
             - secretRef:
                 name: {{ include "openobserve.fullname" . }}

--- a/templates/compactor-deployment.yaml
+++ b/templates/compactor-deployment.yaml
@@ -47,7 +47,7 @@ spec:
           #     path: /
           #     port: http
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.resources.compactor | nindent 12 }}
           envFrom:
             - secretRef:
                 name: {{ include "openobserve.fullname" . }}

--- a/templates/ingester-statefulset.yaml
+++ b/templates/ingester-statefulset.yaml
@@ -68,7 +68,7 @@ spec:
           #     path: /
           #     port: http
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.resources.ingester | nindent 12 }}
           envFrom:
             - secretRef:
                 name: {{ include "openobserve.fullname" . }}

--- a/templates/querier-deployment.yaml
+++ b/templates/querier-deployment.yaml
@@ -50,7 +50,7 @@ spec:
           #     path: /
           #     port: http
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.resources.querier | nindent 12 }}
           envFrom:
             - secretRef:
                 name: {{ include "openobserve.fullname" . }}

--- a/templates/router-deployment.yaml
+++ b/templates/router-deployment.yaml
@@ -50,7 +50,7 @@ spec:
           #     path: /
           #     port: http
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.resources.router | nindent 12 }}
           envFrom:
             - secretRef:
                 name: {{ include "openobserve.fullname" . }}

--- a/values.yaml
+++ b/values.yaml
@@ -193,18 +193,23 @@ ingress:
     #   hosts:
     #     - demo.openobserve.ai
 
+# You can specify resources for each deployment independently.
+# For example, to configure resources for the ingester, use
+# the code below:
+# resources:
+#   ingester:
+#     limits:
+#       cpu: 150m
+#       memory: 512Mi
+#     requests:
+#       cpu: 100m
+#       memory: 128Mi
 resources:
-  {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+  ingester: {}
+  querier: {}
+  compactor: {}
+  router: {}
+  alertmanager: {}
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
This fixes #8. Let me know if you'd like to change the structure of the resources object or the comment.