### PR TITLE
fixed image tag, follow and use Chart.yaml appVersion

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -6,7 +6,7 @@ image:
   repository: public.ecr.aws/zinclabs/openobserve
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.5.2"
+  tag: ""
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
fix typo image tag starts with 'v', So I removed the values overrides.

Reference: https://gallery.ecr.aws/zinclabs/openobserve