### PR TITLE
feature to enable pod health checks

### DIFF
--- a/charts/openobserve/templates/alertmanager-deployment.yaml
+++ b/charts/openobserve/templates/alertmanager-deployment.yaml
@@ -38,14 +38,20 @@ spec:
             - name: http
               containerPort: 5080
               protocol: TCP
-          # livenessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
-          # readinessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
+          {{- if .Values.probes.alertmanager.enabled }}
+          livenessProbe:
+           httpGet:
+             path: /healthz
+             port: http
+           initialDelaySeconds: {{ .Values.probes.alertmanager.initialDelaySeconds | default 60 }}
+           failureThreshold: {{ .Values.probes.alertmanager.failureThreshold | default 3 }}
+          readinessProbe:
+           httpGet:
+             path: /healthz
+             port: http
+           initialDelaySeconds: {{ .Values.probes.alertmanager.initialDelaySeconds | default 60 }}
+           failureThreshold: {{ .Values.probes.alertmanager.failureThreshold | default 3 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources.alertmanager | nindent 12 }}
           envFrom:

--- a/charts/openobserve/templates/compactor-deployment.yaml
+++ b/charts/openobserve/templates/compactor-deployment.yaml
@@ -38,14 +38,20 @@ spec:
             - name: http
               containerPort: 5080
               protocol: TCP
-          # livenessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
-          # readinessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
+          {{- if .Values.probes.compactor.enabled }}
+          livenessProbe:
+           httpGet:
+             path: /healthz
+             port: http
+           initialDelaySeconds: {{ .Values.probes.compactor.initialDelaySeconds | default 60 }}
+           failureThreshold: {{ .Values.probes.compactor.failureThreshold | default 3 }}
+          readinessProbe:
+           httpGet:
+             path: /healthz
+             port: http
+           initialDelaySeconds: {{ .Values.probes.compactor.initialDelaySeconds | default 60 }}
+           failureThreshold: {{ .Values.probes.compactor.failureThreshold | default 3 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources.compactor | nindent 12 }}
           envFrom:

--- a/charts/openobserve/templates/ingester-statefulset.yaml
+++ b/charts/openobserve/templates/ingester-statefulset.yaml
@@ -59,14 +59,20 @@ spec:
               name: http
             - containerPort: 5081
               name: grpc
-          # livenessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
-          # readinessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
+          {{- if .Values.probes.ingester.enabled }}
+          livenessProbe:
+           httpGet:
+             path: /healthz
+             port: http
+           initialDelaySeconds: {{ .Values.probes.ingester.initialDelaySeconds | default 10 }}
+           failureThreshold: {{ .Values.probes.ingester.failureThreshold | default 3 }}
+          readinessProbe:
+           httpGet:
+             path: /healthz
+             port: http
+           initialDelaySeconds: {{ .Values.probes.ingester.initialDelaySeconds | default 10 }}
+           failureThreshold: {{ .Values.probes.ingester.failureThreshold | default 3 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources.ingester | nindent 12 }}
           envFrom:

--- a/charts/openobserve/templates/querier-deployment.yaml
+++ b/charts/openobserve/templates/querier-deployment.yaml
@@ -41,14 +41,20 @@ spec:
               name: http
             - containerPort: 5081
               name: grpc
-          # livenessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
-          # readinessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
+          {{- if .Values.probes.querier.enabled }}
+          livenessProbe:
+           httpGet:
+             path: /healthz
+             port: http
+           initialDelaySeconds: {{ .Values.probes.querier.initialDelaySeconds | default 10 }}
+           failureThreshold: {{ .Values.probes.querier.failureThreshold | default 3 }}
+          readinessProbe:
+           httpGet:
+             path: /healthz
+             port: http
+           initialDelaySeconds: {{ .Values.probes.querier.initialDelaySeconds | default 10 }}
+           failureThreshold: {{ .Values.probes.querier.failureThreshold | default 3 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources.querier | nindent 12 }}
           envFrom:

--- a/charts/openobserve/templates/router-deployment.yaml
+++ b/charts/openobserve/templates/router-deployment.yaml
@@ -41,14 +41,20 @@ spec:
               name: http
             - containerPort: 5081
               name: grpc
-          # livenessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
-          # readinessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
+          {{- if .Values.probes.router.enabled }}
+          livenessProbe:
+           httpGet:
+             path: /healthz
+             port: http
+           initialDelaySeconds: {{ .Values.probes.router.initialDelaySeconds | default 10 }}
+           failureThreshold: {{ .Values.probes.router.failureThreshold | default 3 }}
+          readinessProbe:
+           httpGet:
+             path: /healthz
+             port: http
+           initialDelaySeconds: {{ .Values.probes.router.initialDelaySeconds | default 10 }}
+           failureThreshold: {{ .Values.probes.router.failureThreshold | default 3 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources.router | nindent 12 }}
           envFrom:

--- a/charts/openobserve/values.yaml
+++ b/charts/openobserve/values.yaml
@@ -370,3 +370,15 @@ zplane:
       # - secretName: chart-example-tls
       #   hosts:
       #     - chart-example.local
+
+probes:
+  alertmanager:
+    enabled: false
+  compactor:
+    enabled: false
+  ingester:
+    enabled: false
+  querier:
+    enabled: false
+  router:
+    enabled: false


### PR DESCRIPTION
* Add option to enable health checks (current helm chart had it commented out)
* Ability to configure initial delay and retry timeout
* Health checks are disabled by default for backwards compatibility
