### PR TITLE
Support injecting secrets by overriding env vars.

### DIFF
--- a/charts/openobserve/templates/alertmanager-deployment.yaml
+++ b/charts/openobserve/templates/alertmanager-deployment.yaml
@@ -71,7 +71,9 @@ spec:
           env:
             - name: ZO_NODE_ROLE
               value: "alertmanager"
-
+            {{- with .Values.extraEnv }}
+            {{- toYaml . |  nindent 12 }}
+            {{- end }}
 
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/openobserve/templates/compactor-deployment.yaml
+++ b/charts/openobserve/templates/compactor-deployment.yaml
@@ -71,7 +71,9 @@ spec:
           env:
             - name: ZO_NODE_ROLE
               value: "compactor"
-
+            {{- with .Values.extraEnv }}
+            {{- toYaml . |  nindent 12 }}
+            {{- end }}
 
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/openobserve/templates/ingester-statefulset.yaml
+++ b/charts/openobserve/templates/ingester-statefulset.yaml
@@ -90,6 +90,9 @@ spec:
             - name: ZO_INGESTER_SIDECAR_QUERIER
               value: "false"
             {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . |  nindent 12 }}
+            {{- end }}
           volumeMounts:
             - name: data
               mountPath: /data
@@ -136,6 +139,9 @@ spec:
               value: "50800"
             - name: ZO_GRPC_PORT
               value: "50810"
+            {{- with .Values.extraEnv }}
+            {{- toYaml . |  nindent 12 }}
+            {{- end }}
           volumeMounts:
             - name: data
               mountPath: /data

--- a/charts/openobserve/templates/querier-deployment.yaml
+++ b/charts/openobserve/templates/querier-deployment.yaml
@@ -74,6 +74,9 @@ spec:
           env:
             - name: ZO_NODE_ROLE
               value: "querier"
+            {{- with .Values.extraEnv }}
+            {{- toYaml . |  nindent 12 }}
+            {{- end }}
             
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/openobserve/templates/router-deployment.yaml
+++ b/charts/openobserve/templates/router-deployment.yaml
@@ -74,6 +74,9 @@ spec:
           env:
             - name: ZO_NODE_ROLE
               value: "router"
+            {{- with .Values.extraEnv }}
+            {{- toYaml . |  nindent 12 }}
+            {{- end }}
             
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/openobserve/values.yaml
+++ b/charts/openobserve/values.yaml
@@ -192,6 +192,14 @@ config:
   RUST_LOG: "info"
   RUST_BACKTRACE: "0"
 
+# Add extra environment variables to all pods, useful for overriding secrets
+extraEnv: []
+# - name: ZO_S3_SECRET_KEY
+#   valueFrom:
+#     secretKeyRef:
+#       name: s3credentials-secret
+#       key: S3_KEY
+
 service:
   type: ClusterIP
   # type: LoadBalancer


### PR DESCRIPTION
I would like to commit my values.yml, but that would expose my secrets (like the S3 key). This could be solved by overriding the S3_key env var using a value from a different secret (managed and inject externally). This pull requests adds support for adding extra environment variables to all pods.
