### PR TITLE
fixing probe port for querier container in ingester pod

### DIFF
--- a/charts/openobserve/templates/ingester-statefulset.yaml
+++ b/charts/openobserve/templates/ingester-statefulset.yaml
@@ -111,13 +111,13 @@ spec:
           livenessProbe:
            httpGet:
              path: /healthz
-             port: http
+             port: http-q
            initialDelaySeconds: {{ .Values.probes.ingester.initialDelaySeconds | default 10 }}
            failureThreshold: {{ .Values.probes.ingester.failureThreshold | default 3 }}
           readinessProbe:
            httpGet:
              path: /healthz
-             port: http
+             port: http-q
            initialDelaySeconds: {{ .Values.probes.ingester.initialDelaySeconds | default 10 }}
            failureThreshold: {{ .Values.probes.ingester.failureThreshold | default 3 }}
           {{- end }}


### PR DESCRIPTION
Fix for the port name in healthcheck for the new querier container inside ingester pod.

Recently, new querier container has been added for ingester pod. It exposes two ports http-q and grpc-q. Probe for querier container is configured to use port "http", instead of "http-q". This prevented pod from becoming healthy.