### PR TITLE
change openobserve-standalone chart name from openobserve to openobserve-standalone

### DIFF
--- a/charts/openobserve-standalone/Chart.yaml
+++ b/charts/openobserve-standalone/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: openobserve
+name: openobserve-standalone
 description:  Logs, Metrics and Traces, Dashboards, RUM, Error tracking, Session replay etc. Elasticsearch API compatibility.
 
 # A chart can be either an 'application' or a 'library' chart.


### PR DESCRIPTION
There was a conflict with openobserve HA as both charts produced `openobserve-<version>.tgz` archive. Also it already rewritten `openobserve-0.7.29.tgz` in public repo, so it should be deleted or replaced by actual openobserve HA chart v0.7.29