### PR TITLE
Add configuration option for clusterDomain and explicitly set default cluster domain for etcd for visibility.

### DIFF
--- a/charts/openobserve/templates/configmap.yaml
+++ b/charts/openobserve/templates/configmap.yaml
@@ -11,7 +11,7 @@ data:
   {{- if not .Values.etcd.enabled }}
   ZO_ETCD_ADDR: "{{ .Values.etcd.externalUrl }}"
   {{- else }}
-  ZO_ETCD_ADDR: "{{ .Release.Name }}-etcd-headless.{{ .Release.Namespace }}.svc.cluster.local:2379"
+  ZO_ETCD_ADDR: "{{ .Release.Name }}-etcd-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:2379"
   {{- end }}
   ZO_HTTP_PORT: "{{ .Values.config.ZO_HTTP_PORT }}"
   ZO_HTTP_ADDR: "{{ .Values.config.ZO_HTTP_ADDR }}"
@@ -125,7 +125,7 @@ data:
   ZO_SLED_PREFIX: "{{ .Values.config.ZO_SLED_PREFIX }}"
   {{- if .Values.minio.enabled }}
   ZO_S3_PROVIDER: "minio"
-  ZO_S3_SERVER_URL: "http://{{ .Release.Name }}-minio.{{ .Release.Namespace }}.svc.cluster.local:9000"
+  ZO_S3_SERVER_URL: "http://{{ .Release.Name }}-minio.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:9000"
   ZO_S3_REGION_NAME: "us-east-1"
   ZO_S3_BUCKET_NAME: "{{ (index .Values.minio.buckets 0 ).name }}"
   {{- else }}

--- a/charts/openobserve/templates/zplane-deployment.yaml
+++ b/charts/openobserve/templates/zplane-deployment.yaml
@@ -55,7 +55,7 @@ spec:
             - name: ZPLANE_ZO_PASSWORD
               value: "{{ .Values.auth.ZO_ROOT_USER_PASSWORD }}"
             - name: ZPLANE_ZO_ENDPOINT
-              value: "http://{{ include "openobserve.fullname" . }}-router.{{ .Release.Namespace }}.svc.cluster.local:5080"
+              value: "http://{{ include "openobserve.fullname" . }}-router.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:5080"
 
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/openobserve/values.yaml
+++ b/charts/openobserve/values.yaml
@@ -19,7 +19,7 @@ image:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
-clusterDomain: &clusterDomain "cluster.local"
+clusterDomain: "cluster.local"
 
 serviceAccount:
   # Specifies whether a service account should be created
@@ -342,7 +342,7 @@ etcd:
   enabled: true # if true then etcd will be deployed as part of openobserve
   externalUrl: "my_custom_host.com:2379" # if enabled is false then this is required
   replicaCount: 3 # if enabled is true then this is required. should be odd number
-  clusterDomain: *clusterDomain
+  clusterDomain: "cluster.local"
   image:
     registry: docker.io
     repository: bitnami/etcd

--- a/charts/openobserve/values.yaml
+++ b/charts/openobserve/values.yaml
@@ -19,6 +19,7 @@ image:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
+clusterDomain: "cluster.local"
 
 serviceAccount:
   # Specifies whether a service account should be created
@@ -341,6 +342,7 @@ etcd:
   enabled: true # if true then etcd will be deployed as part of openobserve
   externalUrl: "my_custom_host.com:2379" # if enabled is false then this is required
   replicaCount: 3 # if enabled is true then this is required. should be odd number
+  clusterDomain: "{{ .Values.etcd.clusterDomain | default .Values.clusterDomain }}"
   image:
     registry: docker.io
     repository: bitnami/etcd

--- a/charts/openobserve/values.yaml
+++ b/charts/openobserve/values.yaml
@@ -19,7 +19,7 @@ image:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
-clusterDomain: "cluster.local"
+clusterDomain: &clusterDomain "cluster.local"
 
 serviceAccount:
   # Specifies whether a service account should be created
@@ -342,7 +342,7 @@ etcd:
   enabled: true # if true then etcd will be deployed as part of openobserve
   externalUrl: "my_custom_host.com:2379" # if enabled is false then this is required
   replicaCount: 3 # if enabled is true then this is required. should be odd number
-  clusterDomain: "{{ .Values.etcd.clusterDomain | default .Values.clusterDomain }}"
+  clusterDomain: *clusterDomain
   image:
     registry: docker.io
     repository: bitnami/etcd


### PR DESCRIPTION
This PR adds the configuration option that allows for using a cluster domain other than `cluster.local`, which is a hard requirement for some clusters. It also explicitly adds this option in the etcd section. We aren't currently able to make the etcd section's clusterDomain automatically match the global value as this is not currently a feature of helm when using sub charts (https://github.com/helm/helm/pull/6876) so I just added it to the values file so that at least we can be aware of how to set it manually if required.