### PR TITLE
Remove "Commented Out" values loop

### DIFF
--- a/charts/openobserve-standalone/templates/configmap.yaml
+++ b/charts/openobserve-standalone/templates/configmap.yaml
@@ -6,9 +6,6 @@ metadata:
   labels:
     {{- include "openobserve.labels" . | nindent 4 }}
 data:
-# {{- with .Values.config }}
-# {{- toYaml . |  nindent 2 }}
-# {{- end }}
   ZO_LOCAL_MODE: "{{ .Values.config.ZO_LOCAL_MODE }}"
   ZO_LOCAL_MODE_STORAGE: "{{ .Values.config.ZO_LOCAL_MODE_STORAGE }}"
   ZO_HTTP_PORT: "{{ .Values.config.ZO_HTTP_PORT }}"


### PR DESCRIPTION
These comments cause duplicate keys to be generated by helm.
I'm loading this with the Kustomize helm chart inflator, and it does some extra validation and I've confirmed it's the same with the chart in this repo.

Run `helm template --debug openobserve . -f values.yaml` against the standalone and check the configmap
You'll see the data: block start with two comments, you get a big chunk of the values.yaml config: vars, another comment block part way through, and more keys.

The kustomize error that kicked this off:

`% kustomize  build --enable-helm .
Error: map[string]interface {}(nil): yaml: unmarshal errors:
  line 205: mapping key "OTEL_OTLP_HTTP_ENDPOINT" already defined at line 16
  line 285: mapping key "RUST_BACKTRACE" already defined at line 17
  line 284: mapping key "RUST_LOG" already defined at line 18
  <SNIP many of the same key errors>
`

`
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization

namespace: openobserve

helmCharts:
  - name: openobserve-standalone
    repo: https://charts.openobserve.ai
    version: 0.8.4
    releaseName: openobserve
    valuesFile: openobserve-standalone_values.yaml`

openobserve-standalone_values.yaml was a straight unedited copy of the chart values.yaml

Running `helm template`  shows the same errors / issues, it just doesn't cause an error.
