### PR TITLE
feat: ensure that the statefulset upgrade is feasible

### DIFF
--- a/charts/openobserve-standalone/Chart.yaml
+++ b/charts/openobserve-standalone/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.6
+version: 0.10.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/openobserve-standalone/templates/openobserve-service-headless.yaml
+++ b/charts/openobserve-standalone/templates/openobserve-service-headless.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.headless.enabled}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -18,3 +19,4 @@ spec:
       name: grpc
   selector:
     {{- include "openobserve.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/openobserve-standalone/templates/openobserve-statefulset.yaml
+++ b/charts/openobserve-standalone/templates/openobserve-statefulset.yaml
@@ -10,7 +10,12 @@ spec:
   selector:
     matchLabels:
       {{- include "openobserve.selectorLabels" . | nindent 6 }}
+  {{ if .Values.headless.enabled}}
   serviceName: {{ include "openobserve.fullname" . }}-headless
+  {{- end }}
+  {{- if not .Values.headless.enabled}
+  serviceName: {{ include "openobserve.fullname" . }}
+  {{- end }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}

--- a/charts/openobserve-standalone/values.yaml
+++ b/charts/openobserve-standalone/values.yaml
@@ -51,6 +51,8 @@ persistence:
   annotations: {}
   volumePermissions:
     enabled: false
+headless:
+  enabled: true
 
 # Credentials for authentication
 auth:

--- a/charts/openobserve/Chart.yaml
+++ b/charts/openobserve/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.21
+version: 0.10.22
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/openobserve/templates/ingester-service-headless.yaml
+++ b/charts/openobserve/templates/ingester-service-headless.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.ingester.headless.enabled}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -19,3 +20,4 @@ spec:
   selector:
     {{- include "openobserve.selectorLabels" . | nindent 4 }}
     role: ingester
+{{- end }}

--- a/charts/openobserve/templates/ingester-statefulset.yaml
+++ b/charts/openobserve/templates/ingester-statefulset.yaml
@@ -13,7 +13,12 @@ spec:
     matchLabels:
       {{- include "openobserve.selectorLabels" . | nindent 6 }}
       role: ingester
+  {{ if .Values.ingester.headless.enabled}}
   serviceName: {{ include "openobserve.fullname" . }}-ingester-headless
+  {{- end }}
+  {{- if not .Values.ingester.headless.enabled}}
+  serviceName: {{ include "openobserve.fullname" . }}
+  {{- end }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}

--- a/charts/openobserve/values.yaml
+++ b/charts/openobserve/values.yaml
@@ -59,6 +59,8 @@ replicaCount:
   zplane: 1
 
 ingester:
+  headless:
+    enabled: false
   persistence:
     enabled: true
     size: 10Gi


### PR DESCRIPTION
The previous PR was trying to mutate the serviceName of the existing
stateful set, which would require deleting and recreating.
This PR will optionally allow disabling this and allowing upgrades.
 New installations will go through just fine