### PR TITLE
fix: helm notes

### DIFF
--- a/charts/openobserve/templates/NOTES.txt
+++ b/charts/openobserve/templates/NOTES.txt
@@ -15,5 +15,5 @@
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "openobserve.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
-  kubectl --namespace {{ .Release.Namespace }} port-forward svc/openobserve-router 5080:5080
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "openobserve.fullname" . }}-router 5080:5080
 {{- end }}


### PR DESCRIPTION
fix follow error:
> kubectl --namespace openobserve port-forward svc/openobserve-router 5080:5080
Error from server (NotFound): services "openobserve-router" not found