### PR TITLE
Give priority to secretRef in envFrom

### DIFF
--- a/charts/openobserve-standalone/templates/openobserve-statefulset.yaml
+++ b/charts/openobserve-standalone/templates/openobserve-statefulset.yaml
@@ -78,9 +78,9 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           envFrom:
-            - secretRef:
-                name: {{ include "openobserve.fullname" . }}
             - configMapRef:
+                name: {{ include "openobserve.fullname" . }}
+            - secretRef:
                 name: {{ include "openobserve.fullname" . }}
           env:
             {{- with .Values.extraEnv }}

--- a/charts/openobserve/templates/alertmanager-deployment.yaml
+++ b/charts/openobserve/templates/alertmanager-deployment.yaml
@@ -81,10 +81,10 @@ spec:
           resources:
             {{- toYaml .Values.resources.alertmanager | nindent 12 }}
           envFrom:
-            - secretRef:
-                name: {{ if .Values.externalSecret.enabled }}{{ .Values.externalSecret.name }}{{ else }}{{ include "openobserve.fullname" . }}{{ end }}
             - configMapRef:
                 name: {{ include "openobserve.fullname" . }}
+            - secretRef:
+                name: {{ if .Values.externalSecret.enabled }}{{ .Values.externalSecret.name }}{{ else }}{{ include "openobserve.fullname" . }}{{ end }}
           env:
             - name: ZO_NODE_ROLE
               value: "alertmanager"

--- a/charts/openobserve/templates/compactor-deployment.yaml
+++ b/charts/openobserve/templates/compactor-deployment.yaml
@@ -81,10 +81,10 @@ spec:
           resources:
             {{- toYaml .Values.resources.compactor | nindent 12 }}
           envFrom:
-            - secretRef:
-                name: {{ if .Values.externalSecret.enabled }}{{ .Values.externalSecret.name }}{{ else }}{{ include "openobserve.fullname" . }}{{ end }}
             - configMapRef:
                 name: {{ include "openobserve.fullname" . }}
+            - secretRef:
+                name: {{ if .Values.externalSecret.enabled }}{{ .Values.externalSecret.name }}{{ else }}{{ include "openobserve.fullname" . }}{{ end }}
           env:
             - name: ZO_NODE_ROLE
               value: "compactor"

--- a/charts/openobserve/templates/dex-deployment.yaml
+++ b/charts/openobserve/templates/dex-deployment.yaml
@@ -60,9 +60,9 @@ spec:
               mountPath: /etc/dex
               readOnly: true
           envFrom:
-            - secretRef:
-                name: {{ include "openobserve.fullname" . }}
             - configMapRef:
+                name: {{ include "openobserve.fullname" . }}
+            - secretRef:
                 name: {{ include "openobserve.fullname" . }}
           env:
             {{- with .Values.enterprise.dex.extraEnv }}

--- a/charts/openobserve/templates/ingester-statefulset.yaml
+++ b/charts/openobserve/templates/ingester-statefulset.yaml
@@ -106,10 +106,10 @@ spec:
           resources:
             {{- toYaml .Values.resources.ingester | nindent 12 }}
           envFrom:
-            - secretRef:
-                name: {{ if .Values.externalSecret.enabled }}{{ .Values.externalSecret.name }}{{ else }}{{ include "openobserve.fullname" . }}{{ end }}
             - configMapRef:
                 name: {{ include "openobserve.fullname" . }}
+            - secretRef:
+                name: {{ if .Values.externalSecret.enabled }}{{ .Values.externalSecret.name }}{{ else }}{{ include "openobserve.fullname" . }}{{ end }}
           env:
             - name: ZO_NODE_ROLE
               value: "ingester"

--- a/charts/openobserve/templates/querier-deployment.yaml
+++ b/charts/openobserve/templates/querier-deployment.yaml
@@ -83,10 +83,10 @@ spec:
           resources:
             {{- toYaml .Values.resources.querier | nindent 12 }}
           envFrom:
-            - secretRef:
-                name: {{ if .Values.externalSecret.enabled }}{{ .Values.externalSecret.name }}{{ else }}{{ include "openobserve.fullname" . }}{{ end }}
             - configMapRef:
                 name: {{ include "openobserve.fullname" . }}
+            - secretRef:
+                name: {{ if .Values.externalSecret.enabled }}{{ .Values.externalSecret.name }}{{ else }}{{ include "openobserve.fullname" . }}{{ end }}
           env:
             - name: ZO_NODE_ROLE
               value: "querier"

--- a/charts/openobserve/templates/router-deployment.yaml
+++ b/charts/openobserve/templates/router-deployment.yaml
@@ -83,10 +83,10 @@ spec:
           resources:
             {{- toYaml .Values.resources.router | nindent 12 }}
           envFrom:
-            - secretRef:
-                name: {{ if .Values.externalSecret.enabled }}{{ .Values.externalSecret.name }}{{ else }}{{ include "openobserve.fullname" . }}{{ end }}
             - configMapRef:
                 name: {{ include "openobserve.fullname" . }}
+            - secretRef:
+                name: {{ if .Values.externalSecret.enabled }}{{ .Values.externalSecret.name }}{{ else }}{{ include "openobserve.fullname" . }}{{ end }}
           env:
             - name: ZO_NODE_ROLE
               value: "router"


### PR DESCRIPTION
In `envFrom`, if multiple references are specified and keys with the same name, the one specified later takes precedence.

Currently, because `configMapRef` is specified after `secretRef`, even if you specify `ZO_META_POSTGRES_DSN`, etc. in externalSecret, it will be overwritten by the default configMap, i.e. an empty string.

I suggest that `secretRef` be moved after `configMapRef`, as one would normally prefer the value specified in secret over the value specified in ConfigMap.

Should there be any aspects of my proposal that appear deficient or incorrect, I invite and appreciate your feedback.