### PR TITLE
openobserve-collector: bump go auto-instrumentation version

### DIFF
--- a/charts/openobserve-collector/Chart.yaml
+++ b/charts/openobserve-collector/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.7
+version: 0.3.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/openobserve-collector/templates/instrumentation-go.yaml
+++ b/charts/openobserve-collector/templates/instrumentation-go.yaml
@@ -6,8 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 spec:
   go:
-    # image: ghcr.io/openobserve/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.7.0-alpha-5
-    image: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.11.0-alpha
+    image: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.13.0-alpha
   exporter:
     endpoint: http://{{ include "openobserve-collector.fullname" . }}-gateway-collector.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:4318
   propagators:

--- a/index.yaml
+++ b/index.yaml
@@ -2293,6 +2293,20 @@ entries:
   openobserve-collector:
   - apiVersion: v2
     appVersion: 0.99.0
+    created: "2024-06-14T13:12:24.573046+07:00"
+    description: An opinionated installation of OTEL Collector for OpenObserve
+    digest: 58449e7fd1ce2c5279d9a46a6a157622479457867f1541c4a9094dccb127b38d
+    maintainers:
+    - email: hello@openobserve.ai
+      name: OpenObserve
+      url: https://openobserve.ai
+    name: openobserve-collector
+    type: application
+    urls:
+    - openobserve-collector-0.3.8.tgz
+    version: 0.3.8
+  - apiVersion: v2
+    appVersion: 0.99.0
     created: "2024-06-13T15:51:36.749119-07:00"
     description: An opinionated installation of OTEL Collector for OpenObserve
     digest: 2037e63e076f16c64cd89edf191e9d9c228a424b3d5b17db79e85afd02d58a4f
@@ -2924,4 +2938,4 @@ entries:
     urls:
     - openobserve-standalone-0.7.29.tgz
     version: 0.7.29
-generated: "2024-06-13T15:51:36.742025-07:00"
+generated: "2024-06-14T13:12:24.571356+07:00"


### PR DESCRIPTION
add support auto instrument for newer go version

ref: https://github.com/open-telemetry/opentelemetry-go-instrumentation/issues/732

fix:  {"level":"error","ts":1711045263.4401302,"logger":"Instrumentation.Manager","caller":"instrumentation/manager.go:175","msg":"error while loading probes, cleaning up","name":"net/http/server","error":"offset not found: net/http.response:status"}  {"level":"error","ts":1711045263.4401944,"logger":"go.opentelemetry.io/auto","caller":"cli/main.go:109","msg":"instrumentation crashed","error":"offset not found: net/http.response:status"}