### PR TITLE
fix query component hpa type

### DIFF
--- a/charts/openobserve/templates/querier-hpa.yaml
+++ b/charts/openobserve/templates/querier-hpa.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
-    kind: Deployment
+    kind: StatefulSet
     name: {{ include "openobserve.fullname" . }}-querier
   minReplicas: {{ .Values.autoscaling.querier.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.querier.maxReplicas }}


### PR DESCRIPTION
fix hpa error:
deployments/scale.apps "o2-openobserve-querier" not found