### PR TITLE
add the default storageclass configuration for NATS

### DIFF
--- a/charts/openobserve/values.yaml
+++ b/charts/openobserve/values.yaml
@@ -438,6 +438,7 @@ nats:
         pvc:
           enabled: true
           size: 20Gi
+          storageClassName: ""
     promExporter:
       enabled: true
       podMonitor:


### PR DESCRIPTION
add the default storageclass configuration for NATS, like other components, without requiring users to search for the NATS helm source code to seek how to configure the item. GP3 has become mainstream, not the default GP2.