### PR TITLE
If autoscaling is defined, do not specify replicas

### DIFF
--- a/charts/openobserve/templates/compactor-deployment.yaml
+++ b/charts/openobserve/templates/compactor-deployment.yaml
@@ -6,7 +6,9 @@ metadata:
   labels:
     {{- include "openobserve.labels" . | nindent 4 }}
 spec:
+  {{- if not .Values.autoscaling.compactor.enabled }}
   replicas: {{ .Values.replicaCount.compactor }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "openobserve.selectorLabels" . | nindent 6 }}

--- a/charts/openobserve/templates/querier-statefulset.yaml
+++ b/charts/openobserve/templates/querier-statefulset.yaml
@@ -7,9 +7,7 @@ metadata:
     {{- include "openobserve.labels" . | nindent 4 }}
 spec:
   serviceName: "{{ include "openobserve.fullname" . }}-querier"
-  {{- if not .Values.autoscaling.querier.enabled }}
   replicas: {{ .Values.replicaCount.querier }}
-  {{- end }}
   podManagementPolicy: Parallel
   updateStrategy:
     type: RollingUpdate

--- a/charts/openobserve/templates/querier-statefulset.yaml
+++ b/charts/openobserve/templates/querier-statefulset.yaml
@@ -7,7 +7,9 @@ metadata:
     {{- include "openobserve.labels" . | nindent 4 }}
 spec:
   serviceName: "{{ include "openobserve.fullname" . }}-querier"
+  {{- if not .Values.autoscaling.querier.enabled }}
   replicas: {{ .Values.replicaCount.querier }}
+  {{- end }}
   podManagementPolicy: Parallel
   updateStrategy:
     type: RollingUpdate


### PR DESCRIPTION
This was already handled properly in a few of the other deployments/statefulsets.