### PR TITLE
OpenTelemetryCollector v1alpha1 is deprecated. Migrate to v1beta1

### DIFF
--- a/charts/openobserve-collector/templates/agent.yaml
+++ b/charts/openobserve-collector/templates/agent.yaml
@@ -1,4 +1,4 @@
-apiVersion: opentelemetry.io/v1alpha1
+apiVersion: opentelemetry.io/v1beta1
 kind: OpenTelemetryCollector
 metadata:
   name: {{ include "openobserve-collector.fullname" . }}-agent
@@ -39,11 +39,16 @@ spec:
       readOnly: true
       mountPath: /var/lib/docker/containers
   resources: {{ .Values.gateway.resources | toYaml | nindent 4 }}
-  config: |
-    receivers: {{ .Values.agent.receivers | toYaml | nindent 6 }}
-    connectors: {{ .Values.agent.connectors | toYaml | nindent 6 }}
-    processors: {{ .Values.agent.processors | toYaml | nindent 6 }}
-    extensions: {{ .Values.agent.extensions | toYaml | nindent 6 }}
-    exporters: {{ .Values.exporters | toYaml | nindent 6 }}
-    service: {{ .Values.agent.service | toYaml | nindent 6 }}
-  
+  config:
+    receivers:
+{{ toYaml .Values.agent.receivers | indent 6 }}
+    connectors:
+{{ toYaml .Values.agent.connectors | indent 6 }}
+    processors:
+{{ toYaml .Values.agent.processors | indent 6 }}
+    extensions:
+{{ toYaml .Values.agent.extensions | indent 6 }}
+    exporters:
+{{ toYaml .Values.exporters | indent 6 }}
+    service:
+{{ toYaml .Values.agent.service | indent 6 }}

--- a/charts/openobserve-collector/templates/clusterrole.yaml
+++ b/charts/openobserve-collector/templates/clusterrole.yaml
@@ -8,8 +8,9 @@ metadata:
 rules:
 - nonResourceURLs: ["/metrics", "/metrics/cadvisor"]
   verbs: ["get", "list", "watch"]
-- apiGroups: [ ""]
+- apiGroups: [""]
   resources:
+  - configmaps
   - endpoints
   - events
   - namespaces

--- a/charts/openobserve-collector/templates/clusterrole.yaml
+++ b/charts/openobserve-collector/templates/clusterrole.yaml
@@ -33,6 +33,8 @@ rules:
   resources:
   - servicemonitors
   - podmonitors
+  - probes
+  - scrapeconfigs
   verbs: ["*"]
 - apiGroups: ["apps"]
   resources:

--- a/charts/openobserve-collector/templates/gateway.yaml
+++ b/charts/openobserve-collector/templates/gateway.yaml
@@ -1,4 +1,4 @@
-apiVersion: opentelemetry.io/v1alpha1
+apiVersion: opentelemetry.io/v1beta1
 kind: OpenTelemetryCollector
 metadata:
   name: {{ include "openobserve-collector.fullname" . }}-gateway
@@ -40,11 +40,16 @@ spec:
   # namespace: openobserve-collector
   # name: prometheus
   # port: 8888
-  config: |
-    receivers: {{ .Values.gateway.receivers | toYaml | nindent 6 }}
-    connectors: {{ .Values.gateway.connectors | toYaml | nindent 6 }}
-    processors: {{ .Values.gateway.processors | toYaml | nindent 6 }}
-    extensions: {{ .Values.gateway.extensions | toYaml | nindent 6 }}
-    exporters: {{ .Values.exporters | toYaml | nindent 6 }}
-    service: {{ .Values.gateway.service | toYaml | nindent 6 }}
-  
+  config:
+    receivers:
+{{ toYaml .Values.gateway.receivers | indent 6 }}
+    connectors:
+{{ toYaml .Values.gateway.connectors | indent 6 }}
+    processors:
+{{ toYaml .Values.gateway.processors | indent 6 }}
+    extensions:
+{{ toYaml .Values.gateway.extensions | indent 6 }}
+    exporters:
+{{ toYaml .Values.exporters | indent 6 }}
+    service:
+{{ toYaml .Values.gateway.service | indent 6 }}

--- a/charts/openobserve-collector/values.yaml
+++ b/charts/openobserve-collector/values.yaml
@@ -19,7 +19,7 @@ image:
   repository: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.105.0"
+  tag: "0.113.0"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Following this issues (#102) i have implemented the new apiVersion of opentelemetry.

This update will need to use at lease the v0.104.0 of the opentelemetry operator (should be okay because it's really outdated)

I have also patched a problem with the warning : 
```
W1107 09:45:48.015059  449507 warnings.go:70] missing the following rules for configmaps: [get]
```

By adding `- configmaps` in the ClusterRole part. 