### PR TITLE
add LoadBalancer service annotations  for router

### DIFF
--- a/charts/openobserve/Chart.lock
+++ b/charts/openobserve/Chart.lock
@@ -9,4 +9,4 @@ dependencies:
   repository: https://charts.min.io
   version: 5.3.0
 digest: sha256:63714207ce2a35dd0dac5d8f70e4c23cb058f1a6f710689dcdbd6fe018221cb0
-generated: "2024-12-08T08:05:18.945711-08:00"
+generated: "2024-12-11T01:39:43.998542619Z"

--- a/charts/openobserve/templates/router-service.yaml
+++ b/charts/openobserve/templates/router-service.yaml
@@ -6,6 +6,10 @@ metadata:
   labels:
     {{- include "openobserve.labels" . | nindent 4 }}
     prometheus.io/scrape: "true"
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/openobserve/values.yaml
+++ b/charts/openobserve/values.yaml
@@ -383,6 +383,11 @@ service:
   http_port: 5080
   grpc_port: 5081
   report_server_port: 5082
+  # if the type of service is LoadBalancer, you can config available annotations for Kubernetes load balancers by cloud provider.
+  # annotations:
+  #  service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+  #  service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+
 
 certIssuer:
   enabled: false


### PR DESCRIPTION
if the type of service is LoadBalancer, you can config available annotations for Kubernetes load balancers by cloud provider.

for aws：

https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/guide/service/annotations/
