### PR TITLE
Use external secret for dex

### DIFF
--- a/charts/openobserve/templates/dex-deployment.yaml
+++ b/charts/openobserve/templates/dex-deployment.yaml
@@ -70,7 +70,7 @@ spec:
             - configMapRef:
                 name: {{ include "openobserve.fullname" . }}
             - secretRef:
-                name: {{ include "openobserve.fullname" . }}
+                name: {{ if .Values.externalSecret.enabled }}{{ .Values.externalSecret.name }}{{ else }}{{ include "openobserve.fullname" . }}{{ end }}
           env:
             {{- with .Values.enterprise.dex.extraEnv }}
             {{- toYaml . |  nindent 12 }}


### PR DESCRIPTION
Dex should use external secret if we enabled it