### PR TITLE
update etcd image tag based on bitnami chart

### DIFF
--- a/charts/openobserve/values.yaml
+++ b/charts/openobserve/values.yaml
@@ -584,7 +584,7 @@ etcd:
   image:
     registry: docker.io
     repository: bitnami/etcd
-    tag: 3.5.8-debian-11-r4
+    tag: 3.5.16-debian-12-r2
     pullPolicy: IfNotPresent
     digest: ""
   auth:


### PR DESCRIPTION
While updating openobserve by helm chart, etcd cluster was not healthy (I followed [the bitnami's guide](https://github.com/bitnami/charts/tree/main/bitnami/etcd#to-900) and even tried just removing existing etcd pods and pvcs and reinstalling it)

When i changed the image tag to the bitnami chart's [default value](https://github.com/bitnami/charts/blob/f6e469a3894493edc1276df342e339c1146f6c49/bitnami/etcd/values.yaml#L84C8-L84C27), etcd cluster started working.

This PR changes the default value of etcd.image.tag to bitnami's default. But I'm curious about why the image tag and repository is fixed in this chart in the first place. I think just removing `etcd.image` values all together could be the cleaner solution.