### PR TITLE
Accept root credentials from existing secret

### DIFF
--- a/charts/openobserve-standalone/templates/openobserve-statefulset.yaml
+++ b/charts/openobserve-standalone/templates/openobserve-statefulset.yaml
@@ -86,6 +86,18 @@ spec:
             - secretRef:
                 name: {{ include "openobserve.fullname" . }}
           env:
+            {{- if .Values.auth.existingRootUserSecret.name }}
+            - name: ZO_ROOT_USER_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.auth.existingRootUserSecret.name }}
+                  key: {{ .Values.auth.existingRootUserSecret.emailKey }}
+            - name: ZO_ROOT_USER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.auth.existingRootUserSecret.name }}
+                  key: {{ .Values.auth.existingRootUserSecret.passwordKey }}
+            {{- end }}
             {{- with .Values.extraEnv }}
             {{- toYaml . |  nindent 12 }}
             {{- end }}

--- a/charts/openobserve-standalone/templates/secret.yaml
+++ b/charts/openobserve-standalone/templates/secret.yaml
@@ -6,8 +6,10 @@ metadata:
   labels: {{- include "openobserve.labels" . | nindent 4 }}
 type: Opaque
 stringData:
+  {{- if not .Values.auth.existingRootUserSecret.name }}
   ZO_ROOT_USER_EMAIL: "{{ .Values.auth.ZO_ROOT_USER_EMAIL }}"
   ZO_ROOT_USER_PASSWORD: "{{ .Values.auth.ZO_ROOT_USER_PASSWORD }}"
+  {{- end }}
   {{- if not .Values.minio.enabled }}
   ZO_S3_ACCESS_KEY: "{{ .Values.auth.ZO_S3_ACCESS_KEY }}"
   {{- else }}

--- a/charts/openobserve-standalone/templates/zplane-deployment.yaml
+++ b/charts/openobserve-standalone/templates/zplane-deployment.yaml
@@ -51,9 +51,23 @@ spec:
             {{- toYaml .Values.zplane.resources | nindent 12 }}
           env:
             - name: ZPLANE_ZO_USERNAME
-              value: "{{ .Values.auth.ZO_ROOT_USER_EMAIL }}"
+              {{- if .Values.auth.existingRootUserSecret.name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.auth.existingRootUserSecret.name }}
+                  key: {{ .Values.auth.existingRootUserSecret.emailKey }}
+              {{- else }}
+              value: {{ .Values.auth.ZO_ROOT_USER_EMAIL | quote }}
+              {{- end }}
             - name: ZPLANE_ZO_PASSWORD
-              value: "{{ .Values.auth.ZO_ROOT_USER_PASSWORD }}"
+              {{- if .Values.auth.existingRootUserSecret.name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.auth.existingRootUserSecret.name }}
+                  key: {{ .Values.auth.existingRootUserSecret.passwordKey }}
+              {{- else }}
+              value: {{ .Values.auth.ZO_ROOT_USER_PASSWORD | quote }}
+              {{- end }}
             - name: ZPLANE_ZO_ENDPOINT
               value: "http://{{ include "openobserve.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.service.port }}"
 

--- a/charts/openobserve-standalone/values.yaml
+++ b/charts/openobserve-standalone/values.yaml
@@ -61,8 +61,20 @@ headless:
 
 # Credentials for authentication
 auth:
+  # Either specify root user credentials here, or use an existing secret.
+
+  # OpenObserve root user email
   ZO_ROOT_USER_EMAIL: "root@example.com"
+  # OpenObserve root user password
   ZO_ROOT_USER_PASSWORD: "Complexpass#123"
+
+  existingRootUserSecret:
+    # Existing secret with OpenObserve root user credentials.
+    name: ""
+    # Email key to be retrieved from existing secret
+    emailKey: "ZO_ROOT_USER_EMAIL"
+    # Password key to be retrieved from existing secret
+    passwordKey: "ZO_ROOT_USER_PASSWORD"
 
   # do not need to set this if enabled minio is being used. settings will be picked from minio section. Also IRSA is preferred if on EKS. Set the Service account section with the correct IAM role ARN. Refer https://zinc.dev/docs/guide/ha_deployment/#amazon-eks-s3
   ZO_S3_ACCESS_KEY: ""


### PR DESCRIPTION
Adds a feature so that the environment variables `ZO_ROOT_USER_EMAIL` and `ZO_ROOT_USER_PASSWORD` can be sourced from an existing secret.

Example `values.yaml`:

```yaml
auth:
  existingRootUserSecret:
    name: my-openobserve-root-user
```

Furthermore, I fixed some minor Helm YAML gotchas: instead of `"{{ .Values.auth.ZO_ROOT_USER_PASSWORD }}"` the code should be `{{ .Values.auth.ZO_ROOT_USER_PASSWORD | quote }}` to properly handle values which contain `\` or `"` characters.