### PR TITLE
Correct the YAML structure dependent on NATS

### DIFF
--- a/charts/openobserve/values.yaml
+++ b/charts/openobserve/values.yaml
@@ -578,11 +578,11 @@ nats:
       enabled: true
       podMonitor:
         enabled: true
-    natsBox:
-      container:
-        image:
-          repository: natsio/nats-box
-          tag: 0.14.5-nonroot
+  natsBox:
+    container:
+      image:
+        repository: natsio/nats-box
+        tag: 0.14.5-nonroot
 
 etcd:
   enabled: false # if true then etcd will be deployed as part of openobserve


### PR DESCRIPTION
The structure of nats box in the original NATS values.yaml was natsBox.container.image, not natsBox.config.container.image
<img width="521" alt="image" src="https://github.com/user-attachments/assets/dfe12760-f826-42f3-aeef-93ca40578732" />
