### PR TITLE
Fix health check paths in router deployment to respect `ZO_BASE_URI`

### DIFF
--- a/charts/openobserve/templates/router-deployment.yaml
+++ b/charts/openobserve/templates/router-deployment.yaml
@@ -75,7 +75,7 @@ spec:
           {{- if .Values.probes.router.enabled }}
           livenessProbe:
             httpGet:
-              path: /healthz
+              path: {{ .Values.config.ZO_BASE_URI | default "" }}/healthz
               port: {{ .Values.config.ZO_HTTP_PORT }}
             initialDelaySeconds: {{ .Values.probes.router.config.livenessProbe.initialDelaySeconds | default 10 }}
             periodSeconds: {{ .Values.probes.router.config.livenessProbe.periodSeconds | default 10 }}
@@ -85,7 +85,7 @@ spec:
             terminationGracePeriodSeconds: {{ .Values.probes.router.config.livenessProbe.terminationGracePeriodSeconds | default 30 }}
           readinessProbe:
             httpGet:
-              path: /healthz
+              path: {{ .Values.config.ZO_BASE_URI | default "" }}/healthz
               port: {{ .Values.config.ZO_HTTP_PORT }}
             initialDelaySeconds: {{ .Values.probes.router.config.readinessProbe.initialDelaySeconds | default 10 }}
             periodSeconds: {{ .Values.probes.router.config.readinessProbe.periodSeconds | default 10 }}


### PR DESCRIPTION
This PR addresses an issue where setting the `ZO_BASE_URI` environment variable causes the liveness and readiness probes in the router deployment to fail. By updating the probe paths to include the `ZO_BASE_URI` prefix, the health checks now correctly reflect the application's base URI, allowing the pods to start and operate as expected.​

**Changes:**
Modify the `livenessProbe` and `readinessProbe` paths in the router deployment to prepend the value of `ZO_BASE_URI`.​

**Testing:**
1. Deploy the Helm chart with ZO_BASE_URI set in Values.config.​
2. Verify that the router pod starts successfully.​
3. Confirm that the liveness and readiness probes pass without errors.​