### PR TITLE
OpenFGA currently only uses the database URI from an external secret in the init container

### DIFF
--- a/charts/openobserve/templates/openfga-deployment.yaml
+++ b/charts/openobserve/templates/openfga-deployment.yaml
@@ -47,14 +47,21 @@ spec:
           env:
             - name: OPENFGA_DATASTORE_ENGINE
               value: postgres
+            {{- if .Values.postgres.enabled }}
             - name: OPENFGA_DATASTORE_URI
-              {{- if .Values.postgres.enabled }}
               value: "postgres://openobserve:{{ .Values.postgres.spec.password }}@{{ include "openobserve.fullname" . }}-postgres-rw.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:5432/app?sslmode=disable"
-              {{- else }}
+            {{- else if .Values.auth.ZO_META_POSTGRES_DSN }}
+            - name: OPENFGA_DATASTORE_URI
               value: "{{ .Values.auth.ZO_META_POSTGRES_DSN }}"
-              {{- end }}
+            {{- else if .Values.config.ZO_META_POSTGRES_DSN }}
+            - name: OPENFGA_DATASTORE_URI
+              value: "{{ .Values.config.ZO_META_POSTGRES_DSN }}"
+            {{- end }}
             - name: OPENFGA_LOG_FORMAT
               value: json
+          envFrom:
+            - secretRef:
+                name: {{ if .Values.externalSecret.enabled }}{{ .Values.externalSecret.name }}{{ else }}{{ include "openobserve.fullname" . }}{{ end }}
           ports:
             - containerPort: 8080
               name: http


### PR DESCRIPTION
This patches the template so that the database URI is correctly set in all containers for OpenFGA, it's copy-paste from the patch for issue #135 