### PR TITLE
Added missing ingester.persistence.enabled conditions

### DIFF
--- a/charts/openobserve/templates/ingester-statefulset.yaml
+++ b/charts/openobserve/templates/ingester-statefulset.yaml
@@ -139,9 +139,11 @@ spec:
             {{- with .Values.ingester.extraEnv }}
             {{- toYaml . |  nindent 12 }}
             {{- end }}
+          {{- if .Values.ingester.persistence.enabled }}
           volumeMounts:
             - name: data
               mountPath: /data
+          {{- end }}
       {{- with .Values.nodeSelector.ingester }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -154,6 +156,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+  {{- if .Values.ingester.persistence.enabled }}
   volumeClaimTemplates:
   - metadata:
       name: data
@@ -166,3 +169,5 @@ spec:
       resources:
         requests:
           storage: {{ .Values.ingester.persistence.size | quote }}
+  {{- end }}
+


### PR DESCRIPTION
The value for `ingester.persistence.enabled` is currently checked for the `volume-permissions` init container but missing for the ingester container volume mount and the volumeClaimTemplate.