### PR TITLE
[fix] adding pod resource definitions for `openfga` deployment 

### DIFF
--- a/charts/openobserve/templates/openfga-deployment.yaml
+++ b/charts/openobserve/templates/openfga-deployment.yaml
@@ -38,13 +38,20 @@ spec:
             - secretRef:  # postgres detail can be picked up from secret if not found anywhere else
                 name: {{ if .Values.externalSecret.enabled }}{{ .Values.externalSecret.name }}{{ else }}{{ include "openobserve.fullname" . }}{{ end }}
           resources:
+            {{- if .Values.resources.openfga }}
+            {{- toYaml .Values.resources.openfga | nindent 12 }}
+            {{- else }}
             limits:
               cpu: 200m
               memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            {{- end }}
       containers:
         - name: openfga
           image: {{ .Values.enterprise.openfga.image.repository }}:{{ .Values.enterprise.openfga.image.tag }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{ .Values.enterprise.openfga.image.pullPolicy }}
           command: ['/openfga', 'run']
           env:
             - name: OPENFGA_DATASTORE_ENGINE
@@ -93,7 +100,14 @@ spec:
             failureThreshold: {{ .Values.probes.openfga.config.readinessProbe.failureThreshold | default 3 }}
           {{- end }}
           resources:
+            {{- if .Values.resources.openfga }}
+            {{- toYaml .Values.resources.openfga | nindent 12 }}
+            {{- else }}
             limits:
               cpu: 200m
               memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            {{- end }}
 {{- end }}

--- a/charts/openobserve/values.yaml
+++ b/charts/openobserve/values.yaml
@@ -577,6 +577,7 @@ resources:
   alertmanager: {}
   dex: {}
   reportserver: {}
+  openfga: {}
 
 # autoscaling:
 #   enabled: false
@@ -853,7 +854,8 @@ enterprise:
       O2_ACTION_MAX_MILLI_CPU: "128"
       O2_ACTION_MIN_MILLI_CPU: "128"
       O2_ACTION_CONTAINER_IMAGE: "ghcr.io/astral-sh/uv:bookworm-slim"
-    resources: {}
+    resources:
+      {}
       # limits:
       #   cpu: 1000m
       #   memory: 1Gi


### PR DESCRIPTION
Pod resource definitions are mandatory in most enterprise environments and policy engines like OPA or Kyverno prevent deployment of helm charts that are not providing them.

This PR adds `openfga` resource configuration to values.yaml and deployment template.

- Added `openfga` resource section in values.yaml.
- Updated `openfga-deployment.yaml` to conditionally apply resource limits and requests based on the new configuration.